### PR TITLE
Fix `clean_graph` bad unpacking for #56

### DIFF
--- a/pancat/grapher.py
+++ b/pancat/grapher.py
@@ -177,7 +177,7 @@ def multigraph_viewer(
 
     # Creating pgGraphs object
     gfa_graph_A: Graph = clean_graph(
-        extract_subgraph(
+        *extract_subgraph(
             gfa_path=file_A,
             x=start,
             y=end,
@@ -187,7 +187,7 @@ def multigraph_viewer(
         )
     )
     gfa_graph_B: Graph = clean_graph(
-        extract_subgraph(
+        *extract_subgraph(
             gfa_path=file_B,
             x=start,
             y=end,


### PR DESCRIPTION
This PR fixes issue #56 where when selecting nodes, incorrect mapping of `extract_subgraph` func were given to `clean_graph` resolving in a missing parameter error.